### PR TITLE
fix typo on event name

### DIFF
--- a/source/event_bridge/main.tf
+++ b/source/event_bridge/main.tf
@@ -240,7 +240,7 @@ resource "aws_cloudwatch_event_target" "cctran_cw" {
 }
 
 resource "aws_cloudwatch_event_rule" "merchant" {
-  name = "cc-transactions-posted"
+  name = "cc-transactions-merchant"
   event_bus_name = aws_cloudwatch_event_bus.this.name
   event_pattern = jsonencode(
 


### PR DESCRIPTION
cc-transaction-posted is used as a name twice which results in a duplicate and the typo is now fixed

*Issue #, if available:*

*Description of changes:*
cc-transaction-posted is used as a name twice which results in a duplicate and the typo is now fixed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
